### PR TITLE
Lazy-load easyocr, switch to opencv-headless, and initialize OCR reader on demand

### DIFF
--- a/pages/app.py
+++ b/pages/app.py
@@ -12,8 +12,6 @@ import requests
 import pdfplumber
 from gtts import gTTS
 from textwrap import wrap
-import easyocr
-import cv2
 import numpy as np
 from PIL import Image
 import tempfile
@@ -66,6 +64,7 @@ def get_font_for_language(language):
 def get_ocr_reader():
     """Initialize and cache OCR reader"""
     try:
+        import easyocr
         # Support only English and Hindi for maximum compatibility
         reader = easyocr.Reader(['en', 'hi'], gpu=False)
         return reader
@@ -510,8 +509,6 @@ text = ""
 
 # Initialize OCR reader
 ocr_reader = None
-if input_method == "Upload PDF or Image":
-    ocr_reader = get_ocr_reader()
 
 # Handle input
 if input_method == "Upload PDF or Image":
@@ -525,6 +522,7 @@ if input_method == "Upload PDF or Image":
             
             # Check if PDF is image-based or text-based
             if is_pdf_image_based(pdf_bytes):
+                ocr_reader = get_ocr_reader()
                 text = extract_text_from_image_pdf(pdf_bytes, ocr_reader)
             else:
                 try:
@@ -534,11 +532,13 @@ if input_method == "Upload PDF or Image":
                             if page_text:
                                 text += page_text
                 except Exception as e:
+                    ocr_reader = get_ocr_reader()
                     text = extract_text_from_image_pdf(pdf_bytes, ocr_reader)
         
         else:
             # Handle image file
             try:
+                ocr_reader = get_ocr_reader()
                 # Display a small thumbnail of the uploaded image
                 image = Image.open(uploaded_file)
                 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ gTTS
 fpdf
 reportlab
 easyocr
-opencv-python
+opencv-python-headless
 pdf2image
 PyMuPDF


### PR DESCRIPTION
### Motivation

- Reduce startup/import overhead and avoid failing imports in environments without OCR dependencies by deferring `easyocr` initialization to runtime.  
- Support headless deployments by replacing `opencv-python` with `opencv-python-headless`.  

### Description

- Removed global imports of `easyocr` and `cv2` and moved the `easyocr` import into a cached `get_ocr_reader()` function decorated with `@st.cache_resource`.  
- Updated `requirements.txt` to replace `opencv-python` with `opencv-python-headless`.  
- Changed logic to initialize the OCR reader on demand by calling `get_ocr_reader()` only when processing image-based PDFs, when PDF text extraction falls back to OCR, and when handling uploaded image files.  
- Preserved text preprocessing and font configuration while keeping image upload flow that shows a thumbnail and extraction progress messages.  

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd441618ec83208f104f14ab3f8f56)