### PR TITLE
Add Render keep-alive cron job

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@
 
 👉 [Launch BhashaAI on Streamlit](https://bhashaai.streamlit.app/app)
 
+## ⚙️ Keep-Alive on Render
+
+If you deploy BhashaAI on Render's free or spin-down-prone infrastructure, the web service can go idle after a period of inactivity. This repo now includes a Render cron job that pings the live app every 5 minutes to reduce cold starts.
+
+### Setup
+
+1. Sync `render.yaml` in Render so the new `bhashaai-keepalive` cron job is created.
+2. In the Render dashboard, set `KEEP_ALIVE_URL` for the cron job to your live app URL, for example `https://bhashaai.onrender.com/`.
+3. Redeploy or trigger the cron job once manually to verify the ping succeeds.
+
+### Important note
+
+This approach helps keep the app warm only if your hosting plan allows periodic external requests to wake and maintain the service. If your hosting tier enforces hard sleeping limits, upgrading the instance plan is the only guaranteed always-on option.
+
 ## 🧑‍🤝‍🧑 Who It's For
 
 - 👵 Senior citizens confused by English documents  

--- a/keep_alive.py
+++ b/keep_alive.py
@@ -1,0 +1,54 @@
+import os
+import sys
+from datetime import datetime, timezone
+
+import requests
+
+
+DEFAULT_TIMEOUT_SECONDS = 30
+VALID_STATUSES = {200, 301, 302, 307, 308}
+
+
+def get_target_url() -> str:
+    target_url = os.getenv("KEEP_ALIVE_URL", "").strip()
+    if not target_url:
+        raise ValueError(
+            "KEEP_ALIVE_URL is not set. Configure it in Render with your live app URL, "
+            "for example https://bhashaai.onrender.com/."
+        )
+    return target_url
+
+
+def ping(url: str, timeout_seconds: int) -> requests.Response:
+    headers = {
+        "User-Agent": "BhashaAI-KeepAlive/1.0",
+        "Cache-Control": "no-cache",
+    }
+    return requests.get(url, headers=headers, timeout=timeout_seconds)
+
+
+def main() -> int:
+    timestamp = datetime.now(timezone.utc).isoformat()
+    timeout_seconds = int(os.getenv("KEEP_ALIVE_TIMEOUT", DEFAULT_TIMEOUT_SECONDS))
+
+    try:
+        target_url = get_target_url()
+        response = ping(target_url, timeout_seconds)
+
+        print(
+            f"[{timestamp}] keep-alive ping -> {target_url} "
+            f"status={response.status_code} elapsed={response.elapsed.total_seconds():.2f}s"
+        )
+
+        if response.status_code not in VALID_STATUSES:
+            print(f"Unexpected status code: {response.status_code}", file=sys.stderr)
+            return 1
+
+        return 0
+    except Exception as exc:
+        print(f"[{timestamp}] keep-alive ping failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,19 @@ services:
     name: bhashaai
     runtime: python
     buildCommand: "pip install -r requirements.txt"
-    startCommand: "streamlit run pages/app.py"
+    startCommand: "streamlit run pages/app.py --server.port $PORT --server.address 0.0.0.0"
     envVars:
       - key: GROQ_API_KEY
         sync: false  # You will set it manually in the Render dashboard
+
+  - type: cron
+    name: bhashaai-keepalive
+    runtime: python
+    schedule: "*/5 * * * *"
+    buildCommand: "pip install -r requirements.txt"
+    startCommand: "python keep_alive.py"
+    envVars:
+      - key: KEEP_ALIVE_URL
+        sync: false  # Set this to your live Render URL or custom domain
+      - key: KEEP_ALIVE_TIMEOUT
+        value: "30"


### PR DESCRIPTION
### Motivation
- Free Render instances can idle and cause long cold starts, so the deployment needs a lightweight automated ping to keep the app responsive.
- The Streamlit start command must bind to Render's port/address to run correctly in the Render environment.

### Description
- Add `keep_alive.py`, a small utility that performs a GET against `KEEP_ALIVE_URL`, prints status and elapsed time, and returns a non-zero exit code on failures.
- Update `render.yaml` to run Streamlit with `--server.port $PORT --server.address 0.0.0.0` and add a `bhashaai-keepalive` `cron` service scheduled every 5 minutes that runs `python keep_alive.py` with configurable `KEEP_ALIVE_URL` and `KEEP_ALIVE_TIMEOUT` env vars.
- Document the new keep-alive cron and setup steps in `README.md` with guidance to configure `KEEP_ALIVE_URL` in the Render dashboard and a note about hosting limits.

### Testing
- Ran `python -m py_compile keep_alive.py home.py pages/app.py wake_up.py utils/*.py` to validate syntax, and it succeeded.
- Parsed `render.yaml` using a small Python snippet (`yaml.safe_load`) to confirm two services exist (`web` and `cron`), and it succeeded.
- Exercised `keep_alive.py` end-to-end against a local server using `KEEP_ALIVE_URL=http://127.0.0.1:8765 python keep_alive.py`, which printed a `200` result and succeeded.
- Attempted an external ping (`KEEP_ALIVE_URL=https://example.com python keep_alive.py`) but that outbound request was blocked by the environment proxy (returned `403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd4ab133048320b8213381ff365ba9)