### PR TITLE
Add GitHub Actions keep-alive workflow for Streamlit and document it in README

### DIFF
--- a/.github/workflows/keep-streamlit-awake.yml
+++ b/.github/workflows/keep-streamlit-awake.yml
@@ -1,0 +1,51 @@
+name: Keep Streamlit app awake
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+env:
+  STREAMLIT_KEEPALIVE_URL: https://bhashaai.streamlit.app/app
+
+jobs:
+  ping-app:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Ping the Streamlit app
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os
+          import urllib.error
+          import urllib.request
+          from datetime import datetime, timezone
+
+          url = os.environ["STREAMLIT_KEEPALIVE_URL"]
+          headers = {
+              "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+              "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+              "Accept-Language": "en-US,en;q=0.9",
+              "Cache-Control": "no-cache",
+              "Pragma": "no-cache",
+          }
+          request = urllib.request.Request(url, headers=headers)
+          timestamp = datetime.now(timezone.utc).isoformat()
+
+          print(f"[{timestamp}] Pinging {url}")
+
+          try:
+              with urllib.request.urlopen(request, timeout=60) as response:
+                  body = response.read()
+                  print(f"Status: {response.status}")
+                  print(f"Final URL: {response.geturl()}")
+                  print(f"Downloaded bytes: {len(body)}")
+                  if response.status < 200 or response.status >= 400:
+                      raise SystemExit(f"Unexpected status code: {response.status}")
+          except urllib.error.HTTPError as exc:
+              raise SystemExit(f"HTTP error from keep-alive ping: {exc.code}") from exc
+          except urllib.error.URLError as exc:
+              raise SystemExit(f"URL error from keep-alive ping: {exc.reason}") from exc
+          PY

--- a/README.md
+++ b/README.md
@@ -23,6 +23,31 @@
 
 👉 [Launch BhashaAI on Streamlit](https://bhashaai.streamlit.app/app)
 
+
+## ⚙️ Keep-Alive on GitHub Actions
+
+If you keep BhashaAI deployed on Streamlit Community Cloud, this repo now includes a GitHub Actions workflow that sends a request to the live app every 5 minutes to reduce the chance of the app going to sleep.
+
+### Workflow details
+
+- Workflow file: `.github/workflows/keep-streamlit-awake.yml`
+- Target URL: `https://bhashaai.streamlit.app/app`
+- Trigger: every 5 minutes, plus manual `workflow_dispatch`
+- Request behavior: sends a browser-like GET request to the Streamlit app URL and fails the workflow if GitHub cannot reach the app successfully
+
+### Setup
+
+1. Push this repository to GitHub.
+2. Open the **Actions** tab and enable workflows if GitHub asks.
+3. Run **Keep Streamlit app awake** once manually to verify the ping succeeds.
+4. Keep GitHub Actions enabled for the repository.
+
+### Important notes
+
+- This is a practical keep-alive approach for the current `bhashaai.streamlit.app` deployment, but it is not a hard uptime guarantee if the hosting platform restarts or changes its hibernation behavior.
+- GitHub may disable scheduled workflows in repositories that stay inactive for long periods, so check the Actions tab if the pings ever stop.
+- If the workflow starts failing with HTTP 403 or similar access errors, GitHub-hosted runners may be blocked from reaching the app; in that case, switch to a dedicated uptime service or a self-hosted runner.
+
 ## ⚙️ Keep-Alive on Render
 
 If you deploy BhashaAI on Render's free or spin-down-prone infrastructure, the web service can go idle after a period of inactivity. This repo now includes a Render cron job that pings the live app every 5 minutes to reduce cold starts.


### PR DESCRIPTION
### Motivation

- Prevent the Streamlit Community Cloud deployment from idling by adding an automated keep-alive ping and document how to enable and verify it.

### Description

- Add `/.github/workflows/keep-streamlit-awake.yml` which schedules a job every 5 minutes (and supports `workflow_dispatch`) and runs an inline Python script that issues a browser-like GET to `STREAMLIT_KEEPALIVE_URL` and fails the job on non-2xx responses.
- Update `README.md` to include a `Keep-Alive on GitHub Actions` section describing the workflow file, the target URL, trigger behavior, setup steps, and operational caveats.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd504ece1483209d374830863d371f)